### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.spring-boot-backend
+++ b/Dockerfile.spring-boot-backend
@@ -1,0 +1,11 @@
+FROM maven:3.6.3-jdk-11-slim AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src src
+RUN mvn package -DskipTests
+
+FROM openjdk:11-jre-slim
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO spring-boot-full-stack-professional
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,27 @@
+namespace: spring-boot-full-stack-professional
+
+postgres-database:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgres-database
+    description: Postgres database service
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - spring-boot-full-stack-professional/postgres-database


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration

This PR introduces containerization and deployment configuration for the Spring Boot and React full-stack application. Below is a summary of the changes and the work done to prepare the application for containerized deployment.

## Containerization

### Backend Service (Spring Boot)
- Confirmed that `SpringBootFullStackProfessionalApplication.java` is the main entry point for the Spring Boot backend service.
- Created a Dockerfile for the Spring Boot backend service after resolving issues with the Maven Wrapper. The `.mvn` directory was missing, which caused the initial Dockerfile build to fail. The Dockerfile was modified to use Maven directly instead of the Maven wrapper.
- The backend service Dockerfile has been successfully built and tested, although it cannot connect to the PostgreSQL database when run in isolation due to the absence of the database service.

### Frontend Service (React)
- Attempted to create a Dockerfile for the React frontend service. However, the build process failed because the `package.json` file lacks a 'scripts' section, which is necessary for the `npm start` command.
- Due to the missing 'scripts' section in `package.json`, it was not possible to create a Dockerfile that would successfully build and run the React.js frontend service. The repository owner needs to add the necessary 'start' script to the `package.json` file.

### Database Service (PostgreSQL)
- Searched MonkHub and found a kit for the `postgres-database` service.
- The `postgres-database` service is ready to be used and exposes a port named 'postgres'. It has variables for `db_name`, `db_pass`, and `db_user` already set.

## Deployment Configuration

- Prepared a `monk.yaml` file to allow deployment of the application to monk.io.
- Created a `MANIFEST` file that lists the monk.io YAML files that should be deployed to monk.io.

## Summary

The backend service is containerized and ready for deployment, pending the availability of the database service. The frontend service requires updates to the `package.json` file before it can be containerized. The PostgreSQL database service is identified and ready for use from MonkHub.

Please note that the frontend service Dockerfile cannot be completed until the necessary changes are made to the `package.json` file. The backend service Dockerfile is functional but requires the database service to be operational to connect successfully.

### Next Steps

- Update the `package.json` file in the frontend service to include the 'start' script.
- Ensure that the database service is running and accessible for the backend service to connect to.
- Once the frontend Dockerfile is successfully built, proceed with the deployment configuration for all services.

This PR lays the groundwork for the containerized deployment of the full-stack application and outlines the remaining steps needed to achieve a fully operational deployment.